### PR TITLE
Support serving podcasts behind a proxy

### DIFF
--- a/src/Directory2Rss.ConsoleApp/Program.cs
+++ b/src/Directory2Rss.ConsoleApp/Program.cs
@@ -16,6 +16,7 @@ namespace Directory2Rss.ConsoleApp
         {
             PodcastConfig config = new PodcastConfig();
             config.Listings.Add("<ENTER UNIQUE, SHORT TITLE (NO SPACES)>", new PodcastListing());
+            config.ListingUrl = "<ENTER PUBLIC FACING URL (e.g. http://mywebsite.com OR http://localhost)>";
             config.IPAddress = "<ENTER YOUR IP ADDRESS>";
             config.Listings.FirstOrDefault().Value.PodcastTitle = "<ENTER PODCAST TITLE>";
             config.Listings.FirstOrDefault().Value.DirectoryToServe = "<ENTER DIRECTORY THAT CONTAINS PODCAST (e.g. C:/Podcasts/MyFavoritePodcast)>";

--- a/src/Directory2Rss.ConsoleApp/config.example.json
+++ b/src/Directory2Rss.ConsoleApp/config.example.json
@@ -1,5 +1,6 @@
 {
   "IPAddress": "<ENTER YOUR IP ADDRESS>",
+  "ListingUrl": "<ENTER PUBLIC FACING URL (e.g. http://mywebsite.com OR http://localhost)>",
   "HttpPort": "<ENTER HTTP PORT (DEFAULT IS 80)",
   "Listings": {
     "<ENTER UNIQUE, SHORT TITLE (NO SPACES)>": {

--- a/src/Directory2Rss.Library/Controllers/PodcastDirectoryController.cs
+++ b/src/Directory2Rss.Library/Controllers/PodcastDirectoryController.cs
@@ -33,7 +33,7 @@ namespace Directory2Rss.Library.Controllers
                 writer.WriteLine("<ul>");
                 foreach(var listing in Config.Listings)
                 {
-                    string url = string.Format("http://{0}/{1}/rss", Config.IPAddress, listing.Key);
+                    string url = $"http://{Config.IPAddress}:{Config.HttpPort}/{listing.Key}/rss";
                     writer.WriteLine("<li><a href=\"{0}\">{1}</li>", url, listing.Value.PodcastTitle);
                 }
                 writer.WriteLine("</ul>");
@@ -53,11 +53,10 @@ namespace Directory2Rss.Library.Controllers
             if(Config.Listings.ContainsKey(podcast))
             {
                 PodcastListing localConfig = Config.Listings[podcast];
-                string baseUrl = string.Format("http://{0}", Config.IPAddress);
                 HttpContext.Response.ContentType = "text/xml";
                 using (var writer = HttpContext.OpenResponseText())
                 {
-                    PodcastRss rss = new PodcastRss(localConfig, Config.IPAddress);
+                    PodcastRss rss = new PodcastRss(localConfig, Config.ListingUrl);
                     var files = Directory
                         .EnumerateFiles(localConfig.DirectoryToServe)
                         .Where(f => localConfig.AudioExtensions.Contains(Path.GetExtension(f)))
@@ -81,8 +80,8 @@ namespace Directory2Rss.Library.Controllers
                         {
                             Author = tfile.Tag.FirstAlbumArtist,
                             Title = tfile.Tag.Title,
-                            PodcastBaseUrl = baseUrl,
-                            AudioUrl = string.Format("{0}/{1}/files/{2}", baseUrl, podcast, encodedFileName),
+                            PodcastBaseUrl = Config.ListingUrl,
+                            AudioUrl = string.Format("{0}/{1}/files/{2}", Config.ListingUrl, podcast, encodedFileName),
                             PublicationDate = fileDate,
                             Duration = tfile.Properties.Duration.ToString("hh\\:mm\\:ss")
                         };

--- a/src/Directory2Rss.Library/PodcastConfig.cs
+++ b/src/Directory2Rss.Library/PodcastConfig.cs
@@ -11,6 +11,7 @@ namespace Directory2Rss.Library
     {
         public string IPAddress { get; set; }
         public int HttpPort { get; set; }
+        public string ListingUrl { get; set; }
         public Dictionary<string, PodcastListing> Listings { get; set; }
 
         public PodcastConfig()

--- a/src/Directory2Rss.Library/PodcastRss.cs
+++ b/src/Directory2Rss.Library/PodcastRss.cs
@@ -10,12 +10,12 @@ namespace Directory2Rss.Library
         private List<PodcastItem> _items = new List<PodcastItem>();
 
         public PodcastListing Listing { get; set; }
-        public string IpAddress { get; set; }
+        public string ListingUrl { get; set; }
 
-        public PodcastRss(PodcastListing listing, string ipAddress)
+        public PodcastRss(PodcastListing listing, string listingUrl)
         {
             Listing = listing;
-            IpAddress = ipAddress; 
+            ListingUrl = listingUrl; 
         }
 
         public void AddItem(PodcastItem item)
@@ -50,11 +50,11 @@ namespace Directory2Rss.Library
                     "</channel>\n" +
                 "</rss>",
                 Listing.PodcastTitle,
-                string.Format("http://{0}", IpAddress),
+                ListingUrl,
                 Listing.PodcastOwner,
                 Listing.PodcastDescription,
                 Listing.PodcastOwner,
-                string.Format("http://{0}/image", IpAddress),
+                $"{ListingUrl}/image",
                 Listing.PodcastCategory,
                 itemsXml
                 );


### PR DESCRIPTION
* Added new "ListingUrl" property to Config class to allow users to specify the public-facing url if running behind a proxy
* Fixed another bug where the main page would not provide a correct link to a podcast's RSS feed if an alternate HTTP port was being used
* Updated config.example.json with ListingUrl help text

Addresses bug #8